### PR TITLE
feat: grafana_organization module and simplify vars-structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible Grafana
 
 ![telekom-mms/ansible-role-grafana](https://github.com/telekom-mms/ansible-role-grafana/workflows/test/badge.svg)
-[![Ansible Role](https://img.shields.io/ansible/role/d/57215)](https://galaxy.ansible.com/telekom_mms/grafana)
+[![Ansible Role](https://img.shields.io/ansible/role/d/32178)](https://galaxy.ansible.com/ui/standalone/roles/telekom-mms/grafana/)
 
 Configure Grafana dashboards, folders, datasources, teams and users.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ community.grafana
 
 | Variable | Required | Default |
 | -------- | -------- | ------- |
-| **grafana**
 | grafana_url | yes |
 | grafana_username | yes |
 | grafana_password | yes |

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ![telekom-mms/ansible-role-grafana](https://github.com/telekom-mms/ansible-role-grafana/workflows/test/badge.svg)
 [![Ansible Role](https://img.shields.io/ansible/role/d/32178)](https://galaxy.ansible.com/ui/standalone/roles/telekom-mms/grafana/)
 
-Configure Grafana dashboards, folders, datasources, teams and users.
+Configure Grafana organizations, dashboards, folders, datasources, teams and users.
 
 ## Dependencies
 
-collections:
-community.grafana
+### Collections
+- community.grafana
 
 ## Role Variables
 
@@ -66,18 +66,15 @@ community.grafana
 
 ## Example Playbook
 
-```bash
+```yaml
 ---
 - hosts: localhost
   gather_facts: false
-  collections:
-    - community.grafana
-  roles:
-    - role: grafana
+
   vars:
-    grafana_url: "{{ icinga_url }}/grafanaweb"
-    grafana_username: "{{ icinga_user }}"
-    grafana_password: "{{ icinga_pass }}"
+    grafana_url: "https://monitoring.example.com"
+    grafana_username: "api-user"
+    grafana_password: "******"
 
     grafana_datasources:
       - datasource_object:
@@ -90,4 +87,7 @@ community.grafana
       - folder_object:
         - my_service
         - other_service
+
+  roles:
+    - role: telekom-mms.grafana
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | dashboard_id | no |
 | dashboard_revision | no |
 | commit_message | no |
+<!--- community.grafana 1.6.0 release required
+| [**grafana_organization_users**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_organization_user_module.html)
+| login | yes |
+| role | no |
+| state | no |
+| org_id | no |
+--->
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ community.grafana
 
 | Variable | Required | Default |
 | -------- | -------- | ------- |
-
 | **grafana**
-| url | yes |
-| url_username | yes |
-| url_password | yes |
+| grafana_url | yes |
+| grafana_username | yes |
+| grafana_password | yes |
 | **grafana_users**
 | name | yes |
 | email | no |

--- a/README.md
+++ b/README.md
@@ -84,16 +84,13 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
     grafana_password: "******"
 
     grafana_datasources:
-      - datasource_object:
-        - loki
-        name: "Loki"
+      - name: "Loki"
         ds_type: "loki"
         ds_url: "http://127.0.0.1:3100"
         tls_skip_verify: yes
     grafana_folders:
-      - folder_object:
-        - my_service
-        - other_service
+      - name: my_service
+      - name: other_service
 
   roles:
     - role: telekom-mms.grafana

--- a/README.md
+++ b/README.md
@@ -17,21 +17,24 @@ community.grafana
 | grafana_url | yes |
 | grafana_username | yes |
 | grafana_password | yes |
-| **grafana_users**
+| [**grafana_users**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_user_module.html)
 | name | yes |
 | email | no |
 | login | yes |
 | password | no |
 | is_admin | no |
 | state | no |
-| **grafana_teams**
+| [**grafana_organizations**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_organization_module.html)
+| name | yes |
+| state | no |
+| [**grafana_teams**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_team_module.html)
 | name | yes |
 | email | no |
 | members | no |
 | state | no |
 | enforce_members | no |
 | skip_version_check | no |
-| **grafana_datasources**
+| [**grafana_datasources**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_datasource_module.html)
 | tls_skip_verify | no |
 | org_id | no |
 | name | yes |
@@ -45,11 +48,11 @@ community.grafana
 | password | no |
 | additional_json_data | no |
 | additional_secure_json_data | no |
-| **grafana_folders**
+| [**grafana_folders**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_folder_module.html)
 | name | yes |
 | state | no |
 | skip_version_check | no |
-| **grafana_dashboards**
+| [**grafana_dashboards**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_dashboard_module.html)
 | org_id | no |
 | folder | no |
 | state | no |

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | dashboard_id | no |
 | dashboard_revision | no |
 | commit_message | no |
-<!--- community.grafana 1.6.0 release required
-| [**grafana_organization_users**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_organization_user_module.html)
-| login | yes |
-| role | no |
-| state | no |
-| org_id | no |
---->
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+grafana_organizations: []
 grafana_users: []
 grafana_teams: []
 grafana_datasources: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: telekom_mms
   description: Configure Grafana dashboards, folders, datasources, teams and users
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: [grafana, monitoring]
   platforms:
     - {name: EL, versions: [all]}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,22 +5,10 @@ galaxy_info:
   description: Configure Grafana dashboards, folders, datasources, teams and users
   license: GPLv3
   min_ansible_version: 2.9
-  galaxy_tags:
-    - grafana
-    - monitoring
+  galaxy_tags: [grafana, monitoring]
   platforms:
-    - name: EL
-      versions:
-        - all
-    - name: Fedora
-      versions:
-        - all
-    - name: Amazon
-      versions:
-        - all
-    - name: Debian
-      versions:
-        - all
-    - name: Ubuntu
-      versions:
-        - all
+    - {name: EL, versions: [all]}
+    - {name: Fedora, versions: [all]}
+    - {name: Amazon, versions: [all]}
+    - {name: Debian, versions: [all]}
+    - {name: Ubuntu, versions: [all]}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -28,3 +28,4 @@
       - folder: my_service
         uid: ES5apb27k
         path: test_dashboard.json
+        overwrite: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -28,4 +28,3 @@
       - folder: my_service
         uid: ES5apb27k
         path: test_dashboard.json
-        overwrite: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,21 +15,16 @@
     grafana_password: admin
 
     grafana_datasources:
-      - datasource_object:
-          - loki
-        name: Loki
+      - name: Loki
         ds_type: loki
         ds_url: http://127.0.0.1:3100
         tls_skip_verify: true
 
     grafana_folders:
-      - folder_object:
-          - my_service
-          - other_service
+      - name: my_service
+      - name: other_service
 
     grafana_dashboards:
-      - dashboard_object:
-          - dashboard
-        folder: my_service
-        dashboard_uid: ES5apb27k
+      - folder: my_service
+        uid: ES5apb27k
         path: test_dashboard.json

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -26,5 +26,4 @@
 
     grafana_dashboards:
       - folder: my_service
-        uid: ES5apb27k
         path: test_dashboard.json

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
-collections:
-- name: community.grafana
-  version: 1.5.4
+---
+collections: [{name: community.grafana, version: 1.5.4}]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,18 @@
   loop_control: {loop_var: user}
   tags: user
 
+### community.grafana 1.6.0 release required
+# - name: Manage organization user
+#   community.grafana.grafana_organization_user:
+#     <<: *grafana_connection
+#     login: "{{ organization_user.login }}"
+#     role: "{{ organization_user.role | default(omit) }}"
+#     state: "{{ organization_user.state | default(omit) }}"
+#     org_id: "{{ organization_user.org_id | default(omit) }}"
+#   loop: "{{ grafana_organization_users }}"
+#   loop_control: {loop_var: organization_user}
+#   tags: organization_user
+
 - name: Manage dashboard
   community.grafana.grafana_dashboard:
     <<: *grafana_connection

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,20 +75,6 @@
   loop_control: {loop_var: user}
   tags: user
 
-### community.grafana 1.6.0 release required
-# - name: Manage organization user
-#   community.grafana.grafana_organization_user:
-#     url: "{{ grafana_url }}"
-#     url_username: "{{ grafana_username }}"
-#     url_password: "{{ grafana_password }}"
-#     login: "{{ organization_user.login }}"
-#     role: "{{ organization_user.role | default(omit) }}"
-#     state: "{{ organization_user.state | default(omit) }}"
-#     org_id: "{{ organization_user.org_id | default(omit) }}"
-#   loop: "{{ grafana_organization_users }}"
-#   loop_control: {loop_var: organization_user}
-#   tags: organization_user
-
 - name: Manage dashboard
   community.grafana.grafana_dashboard:
     url: "{{ grafana_url }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,77 +9,72 @@
 - name: Manage datasource
   community.grafana.grafana_datasource:
     <<: *grafana_connection
-    tls_skip_verify: "{{ datasource.0.tls_skip_verify | default(omit) }}"
-    org_id: "{{ datasource.0.org_id | default(omit) }}"
-    name: "{{ datasource.0.name }}"
-    ds_type: "{{ datasource.0.ds_type | default(omit) }}"
-    access: "{{ datasource.0.access | default(omit) }}"
-    ds_url: "{{ datasource.0.ds_url | default(omit) }}"
-    database: "{{ datasource.0.database | default(omit) }}"
-    with_credentials: "{{ datasource.0.with_credentials | default(omit) }}"
-    is_default: "{{ datasource.0.is_default | default(omit) }}"
-    user: "{{ datasource.0.user | default(omit) }}"
-    password: "{{ datasource.0.password | default(omit) }}"
-    additional_json_data: "{{ datasource.0.additional_json_data | default(omit) }}"
-    additional_secure_json_data: "{{ datasource.0.additional_secure_json_data | default(omit) }}"
-  loop: "{{ grafana_datasources | subelements('datasource_object') }}"
-  loop_control:
-    loop_var: datasource
+    tls_skip_verify: "{{ datasource.tls_skip_verify | default(omit) }}"
+    org_id: "{{ datasource.org_id | default(omit) }}"
+    name: "{{ datasource.name }}"
+    ds_type: "{{ datasource.ds_type | default(omit) }}"
+    access: "{{ datasource.access | default(omit) }}"
+    ds_url: "{{ datasource.ds_url | default(omit) }}"
+    database: "{{ datasource.database | default(omit) }}"
+    with_credentials: "{{ datasource.with_credentials | default(omit) }}"
+    is_default: "{{ datasource.is_default | default(omit) }}"
+    user: "{{ datasource.user | default(omit) }}"
+    password: "{{ datasource.password | default(omit) }}"
+    additional_json_data: "{{ datasource.additional_json_data | default(omit) }}"
+    additional_secure_json_data: "{{ datasource.additional_secure_json_data | default(omit) }}"
+  loop: "{{ grafana_datasources }}"
+  loop_control: {loop_var: datasource}
   tags: datasource
 
 - name: Manage folder
   community.grafana.grafana_folder:
     <<: *grafana_connection
-    name: "{{ folder.1 }}"
-    state: "{{ folder.0.state | default(omit) }}"
-    skip_version_check: "{{ folder.0.skip_version_check | default(omit) }}"
-  loop: "{{ grafana_folders | subelements('folder_object') }}"
-  loop_control:
-    loop_var: folder
+    name: "{{ folder.name }}"
+    state: "{{ folder.state | default(omit) }}"
+    skip_version_check: "{{ folder.skip_version_check | default(omit) }}"
+  loop: "{{ grafana_folders }}"
+  loop_control: {loop_var: folder}
   tags: folder
 
 - name: Manage team
   community.grafana.grafana_team:
     <<: *grafana_connection
-    name: "{{ team.1 }}"
-    email: "{{ team.0.email }}"
-    members: "{{ team.0.members | default(omit) }}"
-    state: "{{ team.0.state | default(omit) }}"
-    enforce_members: "{{ team.0.enforce_members | default(omit) }}"
-    skip_version_check: "{{ team.0.skip_version_check | default(omit) }}"
-  loop: "{{ grafana_teams | subelements('team_object') }}"
-  loop_control:
-    loop_var: team
+    name: "{{ team.name }}"
+    email: "{{ team.email }}"
+    members: "{{ team.members | default(omit) }}"
+    state: "{{ team.state | default(omit) }}"
+    enforce_members: "{{ team.enforce_members | default(omit) }}"
+    skip_version_check: "{{ team.skip_version_check | default(omit) }}"
+  loop: "{{ grafana_teams }}"
+  loop_control: {loop_var: team}
   tags: team
 
 - name: Manage user
   community.grafana.grafana_user:
     <<: *grafana_connection
-    name: "{{ user }}"
+    name: "{{ user.name }}"
     email: "{{ user.email | default(omit) }}"
     login: "{{ user.login }}"
     password: "{{ user.password | default(omit) }}"
     is_admin: "{{ user.is_admin | default(omit) }}"
     state: "{{ user.state | default(omit) }}"
   loop: "{{ grafana_users }}"
-  loop_control:
-    loop_var: user
+  loop_control: {loop_var: user}
   tags: user
 
 - name: Manage dashboard
   community.grafana.grafana_dashboard:
     <<: *grafana_connection
-    org_id: "{{ dashboard.0.org_id | default(omit) }}"
-    folder: "{{ dashboard.0.folder | default(omit) }}"
-    state: "{{ dashboard.0.state | default(omit) }}"
-    slug: "{{ dashboard.0.slug | default(omit) }}"
-    uid: "{{ dashboard.0.uid | default(omit) }}"
-    path: "{{ dashboard.0.path | default(omit) }}"
-    overwrite: "{{ dashboard.0.overwrite | default(omit) }}"
-    dashboard_id: "{{ dashboard.0.dashboard_id | default(omit) }}"
-    dashboard_revision: "{{ dashboard.0.dashboard_revision | default(omit) }}"
-    commit_message: "{{ dashboard.0.commit_message | default(omit) }}"
-  loop: "{{ grafana_dashboards | subelements('dashboard_object') }}"
-  loop_control:
-    loop_var: dashboard
+    org_id: "{{ dashboard.org_id | default(omit) }}"
+    folder: "{{ dashboard.folder | default(omit) }}"
+    state: "{{ dashboard.state | default(omit) }}"
+    slug: "{{ dashboard.slug | default(omit) }}"
+    uid: "{{ dashboard.uid | default(omit) }}"
+    path: "{{ dashboard.path | default(omit) }}"
+    overwrite: "{{ dashboard.overwrite | default(omit) }}"
+    dashboard_id: "{{ dashboard.dashboard_id | default(omit) }}"
+    dashboard_revision: "{{ dashboard.dashboard_revision | default(omit) }}"
+    commit_message: "{{ dashboard.commit_message | default(omit) }}"
+  loop: "{{ grafana_dashboards }}"
+  loop_control: {loop_var: dashboard}
   tags: dashboard

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,15 @@
     url_username: "{{ grafana_username }}"
     url_password: "{{ grafana_password }}"
 
+- name: Manage organization
+  community.grafana.grafana_organizations:
+    <<: *grafana_connection
+    name: "{{ organization.name }}"
+    name: "{{ organization.state | default(omit) }}"
+  loop: "{{ grafana_organizations }}"
+  loop_control: {loop_var: organization}
+  tags: organization
+
 # datasource.0 = grafana_datasource attribute
 - name: Manage datasource
   community.grafana.grafana_datasource:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     url_password: "{{ grafana_password }}"
 
 - name: Manage organization
-  community.grafana.grafana_organizations:
+  community.grafana.grafana_organization:
     <<: *grafana_connection
     name: "{{ organization.name }}"
     state: "{{ organization.state | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   community.grafana.grafana_organizations:
     <<: *grafana_connection
     name: "{{ organization.name }}"
-    name: "{{ organization.state | default(omit) }}"
+    state: "{{ organization.state | default(omit) }}"
   loop: "{{ grafana_organizations }}"
   loop_control: {loop_var: organization}
   tags: organization

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
-# datasource.0 = grafana_datasource attribute
-- name: Manage datasource
-  community.grafana.grafana_datasource:
+- name: Grafana connection anchor
+  ansible.builtin.set_fact: &grafana_connection
     url: "{{ grafana_url }}"
     url_username: "{{ grafana_username }}"
     url_password: "{{ grafana_password }}"
+
+# datasource.0 = grafana_datasource attribute
+- name: Manage datasource
+  community.grafana.grafana_datasource:
+    <<: *grafana_connection
     tls_skip_verify: "{{ datasource.0.tls_skip_verify | default(omit) }}"
     org_id: "{{ datasource.0.org_id | default(omit) }}"
     name: "{{ datasource.0.name }}"
@@ -25,9 +29,7 @@
 
 - name: Manage folder
   community.grafana.grafana_folder:
-    url: "{{ grafana_url }}"
-    url_username: "{{ grafana_username }}"
-    url_password: "{{ grafana_password }}"
+    <<: *grafana_connection
     name: "{{ folder.1 }}"
     state: "{{ folder.0.state | default(omit) }}"
     skip_version_check: "{{ folder.0.skip_version_check | default(omit) }}"
@@ -38,9 +40,7 @@
 
 - name: Manage team
   community.grafana.grafana_team:
-    url: "{{ grafana_url }}"
-    url_username: "{{ grafana_username }}"
-    url_password: "{{ grafana_password }}"
+    <<: *grafana_connection
     name: "{{ team.1 }}"
     email: "{{ team.0.email }}"
     members: "{{ team.0.members | default(omit) }}"
@@ -54,9 +54,7 @@
 
 - name: Manage user
   community.grafana.grafana_user:
-    url: "{{ grafana_url }}"
-    url_username: "{{ grafana_username }}"
-    url_password: "{{ grafana_password }}"
+    <<: *grafana_connection
     name: "{{ user }}"
     email: "{{ user.email | default(omit) }}"
     login: "{{ user.login }}"
@@ -70,9 +68,7 @@
 
 - name: Manage dashboard
   community.grafana.grafana_dashboard:
-    grafana_url: "{{ grafana_url }}"
-    grafana_user: "{{ grafana_username }}"
-    grafana_password: "{{ grafana_password }}"
+    <<: *grafana_connection
     org_id: "{{ dashboard.0.org_id | default(omit) }}"
     folder: "{{ dashboard.0.folder | default(omit) }}"
     state: "{{ dashboard.0.state | default(omit) }}"
@@ -87,4 +83,3 @@
   loop_control:
     loop_var: dashboard
   tags: dashboard
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,9 @@
 ---
-- name: Grafana connection anchor
-  ansible.builtin.set_fact: &grafana_connection
+- name: Manage organization
+  community.grafana.grafana_organization:
     url: "{{ grafana_url }}"
     url_username: "{{ grafana_username }}"
     url_password: "{{ grafana_password }}"
-
-- name: Manage organization
-  community.grafana.grafana_organization:
-    <<: *grafana_connection
     name: "{{ organization.name }}"
     state: "{{ organization.state | default(omit) }}"
   loop: "{{ grafana_organizations }}"
@@ -17,7 +13,9 @@
 # datasource.0 = grafana_datasource attribute
 - name: Manage datasource
   community.grafana.grafana_datasource:
-    <<: *grafana_connection
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
     tls_skip_verify: "{{ datasource.tls_skip_verify | default(omit) }}"
     org_id: "{{ datasource.org_id | default(omit) }}"
     name: "{{ datasource.name }}"
@@ -37,7 +35,9 @@
 
 - name: Manage folder
   community.grafana.grafana_folder:
-    <<: *grafana_connection
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
     name: "{{ folder.name }}"
     state: "{{ folder.state | default(omit) }}"
     skip_version_check: "{{ folder.skip_version_check | default(omit) }}"
@@ -47,7 +47,9 @@
 
 - name: Manage team
   community.grafana.grafana_team:
-    <<: *grafana_connection
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
     name: "{{ team.name }}"
     email: "{{ team.email }}"
     members: "{{ team.members | default(omit) }}"
@@ -60,7 +62,9 @@
 
 - name: Manage user
   community.grafana.grafana_user:
-    <<: *grafana_connection
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
     name: "{{ user.name }}"
     email: "{{ user.email | default(omit) }}"
     login: "{{ user.login }}"
@@ -74,7 +78,9 @@
 ### community.grafana 1.6.0 release required
 # - name: Manage organization user
 #   community.grafana.grafana_organization_user:
-#     <<: *grafana_connection
+#     url: "{{ grafana_url }}"
+#     url_username: "{{ grafana_username }}"
+#     url_password: "{{ grafana_password }}"
 #     login: "{{ organization_user.login }}"
 #     role: "{{ organization_user.role | default(omit) }}"
 #     state: "{{ organization_user.state | default(omit) }}"
@@ -85,7 +91,9 @@
 
 - name: Manage dashboard
   community.grafana.grafana_dashboard:
-    <<: *grafana_connection
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
     org_id: "{{ dashboard.org_id | default(omit) }}"
     folder: "{{ dashboard.folder | default(omit) }}"
     state: "{{ dashboard.state | default(omit) }}"


### PR DESCRIPTION
- added `community.grafana.grafana_organization` task
- ~~added `community.grafana.grafana_organization_user` task (disabled, because community.grafana 1.6.0 required)~~
  - removed in favor of #18
- fixed ansible role downloads badge
- fixed and beautify readme variables table
- minify yaml
- ⚠️ removed `subelements('x_object')` filter from several loops
  - I don't understand the benefit of this. In some places it isn't used at all and in other places it is only used for the name, although you can replace this with the key `name`. I'm also wondering why `x_object` is defined as a list.
  - For further support of `x_object`, I could leave the subelements there for now and set a default for `name` if it isn't defined.