### PR TITLE
feat(dashboard): manage by org_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | skip_version_check | no |
 | [**grafana_dashboards**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_dashboard_module.html)
 | org_id | no |
+| org_name | no |
 | folder | no |
 | state | no |
 | slug | no |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,7 @@
     url_username: "{{ grafana_username }}"
     url_password: "{{ grafana_password }}"
     org_id: "{{ dashboard.org_id | default(omit) }}"
+    org_name: "{{ dashboard.org_name | default(omit) }}"
     folder: "{{ dashboard.folder | default(omit) }}"
     state: "{{ dashboard.state | default(omit) }}"
     slug: "{{ dashboard.slug | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,9 +68,6 @@
 
     - name: Manage dashboard
       community.grafana.grafana_dashboard:
-        url: "{{ grafana_url }}"
-        url_username: "{{ grafana_username }}"
-        url_password: "{{ grafana_password }}"
         org_id: "{{ dashboard.org_id | default(omit) }}"
         org_name: "{{ dashboard.org_name | default(omit) }}"
         folder: "{{ dashboard.folder | default(omit) }}"


### PR DESCRIPTION
- depends on https://github.com/ansible-collections/community.grafana/pull/331
- manage your dashboards by specifying `org_name` instead of `org_id`